### PR TITLE
Update boss_loatheb_40.cpp

### DIFF
--- a/src/Naxxramas/scripts/boss_loatheb_40.cpp
+++ b/src/Naxxramas/scripts/boss_loatheb_40.cpp
@@ -22,20 +22,24 @@
 enum Spells
 {
     SPELL_NECROTIC_AURA                         = 55593,
-    // SPELL_SUMMON_SPORE                          = 29234,
-    SPELL_DEATHBLOOM_10                         = 29865,
-    SPELL_DEATHBLOOM_25                         = 55053,
-    SPELL_INEVITABLE_DOOM_10                    = 29204,
-    SPELL_INEVITABLE_DOOM_25                    = 55052,
-    SPELL_BERSERK                               = 26662
+    // SPELL_SUMMON_SPORE                       = 29234,
+    // SPELL_DEATHBLOOM_10                      = 29865, // does 200 dmg every second for 6 seconds with 1200 extra damage at the end. should do 196 dmg every 6 seconds. no extra damage at the end.
+    SPELL_POISON_SHOCK                          = 22595, // does 180-220 aoe poison damage. if Loatheb recasts this every 6 seconds it's a possible fix for poison aura.
+    // SPELL_DEATHBLOOM_25                      = 55053,
+    SPELL_INEVITABLE_DOOM                       = 29204,
+    //SPELL_INEVITABLE_DOOM_25                  = 55052,
+    // SPELL_BERSERK                            = 26662, // he doesn't cast berserk in Naxx40
+    SPELL_REMOVE_CURSE                          = 30281  // He periodically removes all curses on himself
 };
 
 enum Events
 {
     EVENT_NECROTIC_AURA                         = 1,
-    EVENT_DEATHBLOOM                            = 2,
+    // EVENT_DEATHBLOOM                         = 2,
+    EVENT_POISON_SHOCK                          = 2,
     EVENT_INEVITABLE_DOOM                       = 3,
-    EVENT_BERSERK                               = 4,
+    // EVENT_BERSERK                            = 4,
+    EVENT_REMOVE_CURSE                          = 4,
     EVENT_SUMMON_SPORE                          = 5,
     EVENT_NECROTIC_AURA_FADING                  = 6,
     EVENT_NECROTIC_AURA_REMOVED                 = 7
@@ -99,10 +103,12 @@ public:
             BossAI::JustEngagedWith(who);
             me->SetInCombatWithZone();
             events.ScheduleEvent(EVENT_NECROTIC_AURA, 10s);
-            events.ScheduleEvent(EVENT_DEATHBLOOM, 5s);
+            // events.ScheduleEvent(EVENT_DEATHBLOOM, 5s);
+            events.ScheduleEvent(EVENT_POISON_SHOCK, 5s);
             events.ScheduleEvent(EVENT_INEVITABLE_DOOM, 2min);
             events.ScheduleEvent(EVENT_SUMMON_SPORE, 15s);
-            events.ScheduleEvent(EVENT_BERSERK, 12min);
+            // events.ScheduleEvent(EVENT_BERSERK, 12min);
+            events.ScheduleEvent(EVENT_REMOVE_CURSE, 5s);
         }
 
         void JustDied(Unit* killer) override
@@ -123,16 +129,21 @@ public:
             switch (events.ExecuteEvent())
             {
                 case EVENT_SUMMON_SPORE:
+                {
                     me->CastSpell(me, SPELL_SUMMON_SPORE, true);
-                    events.Repeat(35s);
+                    events.Repeat(13s);
                     break;
+                }
                 case EVENT_NECROTIC_AURA:
+                {
                     me->CastSpell(me, SPELL_NECROTIC_AURA, true);
                     Talk(SAY_NECROTIC_AURA_APPLIED);
                     events.ScheduleEvent(EVENT_NECROTIC_AURA_FADING, 14s);
                     events.ScheduleEvent(EVENT_NECROTIC_AURA_REMOVED, 17s);
                     events.Repeat(20s);
                     break;
+                }
+                /*
                 case EVENT_DEATHBLOOM:
                 {
                     int32 bp0 = 33; // TODO: Amplitude should be 6k, but is 1k. 200 dmg after 6 seconds
@@ -140,23 +151,55 @@ public:
                     events.Repeat(30s);
                     break;
                 }
+                */
+    			case EVENT_POISON_SHOCK:
+				{
+	                if (me->CastSpell(me, SPELL_POISON_SHOCK, true) == SPELL_CAST_OK)
+                    {
+                        events.RepeatEvent(6000);
+					}
+					else
+					{
+						events.RepeatEvent(100);	
+					}
+                    break;			
+				}
                 case EVENT_INEVITABLE_DOOM:
                 {
                     int32 bp0 = 2549;
-                    me->CastCustomSpell(me, SPELL_INEVITABLE_DOOM_10, &bp0, 0, 0, false);
-                    doomCounter++;
-                    events.Repeat(doomCounter < 6 ? 30s : 15s);
+
+                    if (me->CastCustomSpell(me, SPELL_INEVITABLE_DOOM, &bp0, 0, 0, false) == SPELL_CAST_OK)
+                    {
+						doomCounter++;
+                        events.RepeatEvent(doomCounter < 6 ? 30s : 15s);
+					}
+					else
+					{
+						events.RepeatEvent(100);	
+					}
                     break;
                 }
+                /*
                 case EVENT_BERSERK:
                     me->CastSpell(me, SPELL_BERSERK, true);
                     break;
+                */
+                case EVENT_REMOVE_CURSE:
+                {
+                    me->CastSpell(me, SPELL_REMOVE_CURSE, true);
+                    events.RepeatEvent(30s);
+                    break;
+                }
                 case EVENT_NECROTIC_AURA_FADING:
+                {
                     Talk(SAY_NECROTIC_AURA_FADING);
                     break;
+                }
                 case EVENT_NECROTIC_AURA_REMOVED:
+                {
                     Talk(SAY_NECROTIC_AURA_REMOVED);
                     break;
+                }
             }
             DoMeleeAttackIfReady();
         }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- now casts Poison Shock every 6 seconds to simulate poison aura
- now casts Remove Curse
- no longer casts Berserk
- no longer casts Deathbloom
- summon spore every 13 seconds instead of 35 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/sogladev/mod-vanilla-naxxramas/issues/2
- Closes https://github.com/sogladev/mod-vanilla-naxxramas/issues/11

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
VMangos, Wowhead
https://github.com/vmangos/core/blob/development/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_loatheb.cpp

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested this in game with Individual Progression, not with this module


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Make yourself immortal with .modify hp 99999999
2. Let the boss smack you around the room for a bit, while you watch the combat console.
